### PR TITLE
feat: Add `huggingface.LocalHFDataset` to `kedro-datasets`

### DIFF
--- a/kedro-datasets/RELEASE.md
+++ b/kedro-datasets/RELEASE.md
@@ -2,6 +2,17 @@
 
 ## Major features and improvements
 
+- Added `huggingface.LocalHFDataset` to handle saving and loading from Hugging Face datasets on a filesystem.
+
+## Bug fixes and other changes
+## Community contributions
+
+[iwhalen](https://github.com/iwhalen)
+
+# Release 9.3.0
+
+## Major features and improvements
+
 - Kedro-Datasets is now compatible with pandas 3.0.
 - Added `ibis-materialize` and `ibis-singlestoredb` extras for the backends added in Ibis 12.0.
 - Added "upsert" save mode to `ibis.TableDataset` (available on backends that support `MERGE INTO` since Ibis 12.0).
@@ -17,8 +28,22 @@
 - Fixed `databricks.ManagedTableDataset` upsert write mode failing with `[CONFIG_NOT_AVAILABLE]` on Databricks Spark Connect runtimes by replacing `spark.conf.set` variable substitution with direct f-string interpolation in the MERGE SQL statement.
 - Fixed `ibis.TableDataset` `exists` method to account for `database` (i.e. the collection of tables, or schema).
 - Relaxed all `gcsfs` upper-bound pins (previously capped below `2023.7`).
+- Added `os.PathLike` support for the following dataset groups (`text`, `json`, `yaml`, `pickle`, `geopandas`, `polars`, `openXML`, `holoview`, `biosequence`, `email` and `geopandas`)
+- Pinned delta-spark upper bound to 4.1
+- Ensured partition paths remain within dataset directory
+- Ensured matplotlib paths remain within dataset directory
 
 ## Community contributions
+
+Many thanks to the following Kedroids for contributing PRs to this release:
+
+[Priyanka](https://github.com/priya-gitTest)
+[Akumawavez](https://github.com/akumawavez)
+[Joris](https://github.com/jorisvane)
+[Bas-commits](https://github.com/Bas-commits)
+[oomenn](https://github.com/oomenn)
+[Celina](https://github.com/celinaczy)
+[Juanchodpg2](https://github.com/juanchodpg2)
 
 # Release 9.2.0
 

--- a/kedro-datasets/docs/api/kedro_datasets/huggingface.LocalHFDataset.md
+++ b/kedro-datasets/docs/api/kedro_datasets/huggingface.LocalHFDataset.md
@@ -1,0 +1,9 @@
+# LocalHFDataset
+
+`LocalHFDataset` saves and loads Hugging Face datasets from a filesystem
+ using the `datasets` library.
+
+::: kedro_datasets.huggingface.LocalHFDataset
+    options:
+        members: true
+        show_source: true

--- a/kedro-datasets/kedro_datasets/__init__.py
+++ b/kedro-datasets/kedro_datasets/__init__.py
@@ -1,7 +1,7 @@
 """``kedro_datasets`` is where you can find all of Kedro's data connectors."""
 
 __all__ = ["KedroDeprecationWarning"]
-__version__ = "9.2.0"
+__version__ = "9.3.0"
 
 import sys
 import warnings

--- a/kedro-datasets/kedro_datasets/huggingface/__init__.py
+++ b/kedro-datasets/kedro_datasets/huggingface/__init__.py
@@ -5,11 +5,12 @@ from typing import Any
 import lazy_loader as lazy
 
 try:
-    from .hugging_face_dataset import HFDataset
+    from .hugging_face_dataset import HFDataset, LocalHFDataset
 except (ImportError, RuntimeError):
     # For documentation builds that might fail due to dependency issues
     # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
     HFDataset: Any
+    LocalHFDataset: Any
 
 try:
     from .transformer_pipeline_dataset import HFTransformerPipelineDataset
@@ -21,7 +22,7 @@ except (ImportError, RuntimeError):
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submod_attrs={
-        "hugging_face_dataset": ["HFDataset"],
+        "hugging_face_dataset": ["HFDataset", "LocalHFDataset"],
         "transformer_pipeline_dataset": ["HFTransformerPipelineDataset"],
     },
 )

--- a/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
@@ -106,7 +106,7 @@ class LocalHFDataset(AbstractVersionedDataset[DatasetLike, DatasetLike]):
         ```
 
         By default, data will be loaded and saved from
-        (Arrow)[https://huggingface.co/docs/datasets/about_arrow] format.
+        [Arrow](https://huggingface.co/docs/datasets/about_arrow) format.
 
         Using the
         [YAML API](https://docs.kedro.org/en/stable/catalog-data/data_catalog_yaml_examples/)
@@ -122,14 +122,8 @@ class LocalHFDataset(AbstractVersionedDataset[DatasetLike, DatasetLike]):
         This saves each individual ``datasets.Dataset`` into separate files
         in the directory in JSON format.
 
-        The ``file_format`` accepts the following arguments:
-
-            - ``arrow``
-            - ``parquet``
-            - ``json``
-            - ``csv``
-            - ``lance``
-            - ``hdf5``
+        The ``file_format`` accepts `arrow`, `parquet`, `json`, `csv`, `lance`,
+        and `hdf5` as arguments.
 
         For more on saving and loading from a filesystem with the Datasets
         library, see

--- a/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
@@ -1,13 +1,33 @@
 from __future__ import annotations
 
+import os
+from copy import deepcopy
+from pathlib import PurePosixPath
 from typing import Any
 
-from datasets import load_dataset
+import fsspec
+from datasets import (
+    Dataset,
+    DatasetDict,
+    IterableDataset,
+    IterableDatasetDict,
+    load_dataset,
+    load_from_disk,
+)
 from huggingface_hub import HfApi
 from kedro.io import AbstractDataset
+from kedro.io.core import (
+    AbstractVersionedDataset,
+    DatasetError,
+    Version,
+    get_filepath_str,
+    get_protocol_and_path,
+)
+
+DatasetLike = Dataset | DatasetDict | IterableDataset | IterableDatasetDict
 
 
-class HFDataset(AbstractDataset):
+class HFDataset(AbstractDataset[None, DatasetLike]):
     """``HFDataset`` loads Hugging Face datasets
     using the `datasets <https://pypi.org/project/datasets>`_ library.
 
@@ -45,7 +65,7 @@ class HFDataset(AbstractDataset):
         self._dataset_kwargs = dataset_kwargs or {}
         self.metadata = metadata
 
-    def load(self):
+    def load(self) -> DatasetLike:
         # TODO: Replace suppression with the solution from here: https://github.com/kedro-org/kedro-plugins/issues/1131
         return load_dataset(self.dataset_name, **self._dataset_kwargs)  # nosec
 
@@ -65,3 +85,261 @@ class HFDataset(AbstractDataset):
     def list_datasets():
         api = HfApi()
         return list(api.list_datasets())
+
+
+class LocalHFDataset(AbstractVersionedDataset[DatasetLike, DatasetLike]):
+    """``LocalHFDataset`` loads/saves Hugging Face ``Dataset``,
+    ``DatasetDict``, ``IterableDataset``, and
+    ``IterableDatasetDict`` objects to/from disk using an
+    underlying filesystem (e.g.: local, S3, GCS). Iterable
+    variants are materialized before saving.
+
+    Examples:
+        Using the
+        [YAML API](https://docs.kedro.org/en/stable/catalog-data/data_catalog_yaml_examples/)
+        with a ``datasets.Dataset``
+
+        ```yaml
+        reviews:
+          type: huggingface.LocalHFDataset
+          path: data/01_raw/reviews.arrow
+        ```
+
+        By default, data will be loaded and saved from
+        (Arrow)[https://huggingface.co/docs/datasets/about_arrow] format.
+
+        Using the
+        [YAML API](https://docs.kedro.org/en/stable/catalog-data/data_catalog_yaml_examples/)
+        with a ``datasets.DatasetDict`` in JSON format:
+
+        ```yaml
+        review_dict:
+            type: huggingface.LocalHFDataset
+            path: data/01_raw/review_dict/
+            file_format: json
+        ```
+
+        This saves each individual ``datasets.Dataset`` into separate files
+        in the directory in JSON format.
+
+        The ``file_format`` accepts the following arguments:
+
+            - ``arrow``
+            - ``parquet``
+            - ``json``
+            - ``csv``
+            - ``lance``
+            - ``hdf5``
+
+        For more on saving and loading from a filesystem with the Datasets
+        library, see
+        [here](https://huggingface.co/docs/datasets/v4.8.4/en/loading#local-and-remote-files).
+
+        Using the
+        [Python API](https://docs.kedro.org/en/stable/catalog-data/advanced_data_catalog_usage/)
+        with a ``datasets.Dataset``:
+
+        >>> from datasets import Dataset
+        >>> from kedro_datasets.huggingface.hugging_face_dataset import (
+        ...     LocalHFDataset,
+        ... )
+        >>>
+        >>> data = Dataset.from_dict(
+        ...     {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}
+        ... )
+        >>>
+        >>> dataset = LocalHFDataset(
+        ...     path=tmp_path / "test_hf_dataset.arrow"
+        ... )
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert reloaded.to_dict() == data.to_dict()
+
+        Using the
+        [Python API](https://docs.kedro.org/en/stable/catalog-data/advanced_data_catalog_usage/)
+        with a ``datasets.DatasetDict``:
+
+        >>> from datasets import Dataset, DatasetDict
+        >>> from kedro_datasets.huggingface.hugging_face_dataset import (
+        ...     LocalHFDataset,
+        ... )
+        >>>
+        >>> data = DatasetDict({
+        ...     "train": Dataset.from_dict(
+        ...         {"col1": [1, 2], "col2": ["a", "b"]}
+        ...     ),
+        ...     "test": Dataset.from_dict(
+        ...         {"col1": [3], "col2": ["c"]}
+        ...     ),
+        ... })
+        >>>
+        >>> dataset = LocalHFDataset(
+        ...     path=tmp_path / "test_hf_dataset_dict"
+        ... )
+        >>> dataset.save(data)
+        >>> reloaded = dataset.load()
+        >>> assert list(reloaded.keys()) == ["train", "test"]
+
+    """
+
+    _SUPPORTED_FORMATS = {"arrow", "parquet", "json", "csv", "lance", "hdf5"}
+    _FORMAT_EXTENSIONS = {
+        "arrow": ".arrow",
+        "parquet": ".parquet",
+        "json": ".json",
+        "csv": ".csv",
+        "lance": ".lance",
+        "hdf5": ".h5",
+    }
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        path: str | os.PathLike,
+        file_format: str = "arrow",
+        version: Version | None = None,
+        load_args: dict[str, Any] | None = None,
+        save_args: dict[str, Any] | None = None,
+        credentials: dict[str, Any] | None = None,
+        fs_args: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if file_format not in self._SUPPORTED_FORMATS:
+            msg = (
+                f"Unsupported file_format '{file_format}'. "
+                f"Must be one of {sorted(self._SUPPORTED_FORMATS)}."
+            )
+            raise DatasetError(msg)
+
+        self._file_format = file_format
+        _fs_args = deepcopy(fs_args) or {}
+        _credentials = deepcopy(credentials) or {}
+
+        protocol, resolved_path = get_protocol_and_path(path, version)
+        self._protocol = protocol
+
+        if protocol == "file":
+            _fs_args.setdefault("auto_mkdir", True)
+
+        self._fs = fsspec.filesystem(self._protocol, **_credentials, **_fs_args)
+
+        self._load_args = load_args or {}
+        self._save_args = save_args or {}
+        self.metadata = metadata
+
+        # storage_options passed to HF's load/save methods
+        self._storage_options = {**_credentials, **_fs_args} or None
+
+        super().__init__(
+            filepath=PurePosixPath(resolved_path),
+            version=version,
+            exists_function=self._fs.exists,
+            glob_function=self._fs.glob,
+        )
+
+    def _load(self) -> DatasetLike:
+        load_path = get_filepath_str(self._get_load_path(), self._protocol)
+
+        if self._file_format == "arrow":
+            return load_from_disk(
+                load_path,
+                storage_options=self._storage_options,
+                **self._load_args,
+            )
+
+        ext = self._FORMAT_EXTENSIONS[self._file_format]
+        loader = getattr(Dataset, f"from_{self._file_format}")
+
+        if self._fs.isdir(load_path):
+            paths = {
+                PurePosixPath(p).stem: p for p in self._fs.glob(f"{load_path}/*{ext}")
+            }
+            return DatasetDict(
+                {
+                    split: loader(path, **self._load_args)
+                    for split, path in paths.items()
+                }
+            )
+
+        return loader(load_path, **self._load_args)
+
+    def _save(self, data: DatasetLike) -> None:
+        if not isinstance(
+            data,
+            Dataset | DatasetDict | IterableDataset | IterableDatasetDict,
+        ):
+            msg = (
+                "LocalHFDataset only supports `datasets.Dataset`, "
+                "`datasets.DatasetDict`, "
+                "`datasets.IterableDataset`, and "
+                "`datasets.IterableDatasetDict` instances. "
+                f"Got {type(data)}"
+            )
+            raise DatasetError(msg)
+
+        if isinstance(data, IterableDatasetDict):
+            data = DatasetDict({k: Dataset.from_list(list(v)) for k, v in data.items()})
+        elif isinstance(data, IterableDataset):
+            data = Dataset.from_list(list(data))
+
+        save_path = get_filepath_str(self._get_save_path(), self._protocol)
+
+        if self._file_format == "arrow":
+            data.save_to_disk(
+                save_path,
+                storage_options=self._storage_options,
+                **self._save_args,
+            )
+        elif isinstance(data, DatasetDict):
+            self._fs.mkdirs(save_path, exist_ok=True)
+            ext = self._FORMAT_EXTENSIONS[self._file_format]
+            saver = f"to_{self._file_format}"
+            for split, split_ds in data.items():
+                split_path = f"{save_path}/{split}{ext}"
+                getattr(split_ds, saver)(
+                    split_path,
+                    storage_options=self._storage_options,
+                    **self._save_args,
+                )
+        else:
+            saver = f"to_{self._file_format}"
+            getattr(data, saver)(
+                save_path,
+                storage_options=self._storage_options,
+                **self._save_args,
+            )
+
+        self._invalidate_cache()
+
+    def _describe(self) -> dict[str, Any]:
+        return {
+            "path": self._filepath,
+            "file_format": self._file_format,
+            "protocol": self._protocol,
+            "version": self._version,
+            "load_args": self._load_args,
+            "save_args": self._save_args,
+        }
+
+    def _exists(self) -> bool:
+        try:
+            load_path = get_filepath_str(self._get_load_path(), self._protocol)
+        except DatasetError:
+            return False
+
+        if self._file_format == "arrow":
+            return self._fs.isdir(load_path) and (
+                self._fs.exists(f"{load_path}/dataset_dict.json")
+                or self._fs.exists(f"{load_path}/dataset_info.json")
+            )
+
+        return self._fs.exists(load_path)
+
+    def _release(self) -> None:
+        super()._release()
+        self._invalidate_cache()
+
+    def _invalidate_cache(self) -> None:
+        """Invalidate underlying filesystem caches."""
+        path = get_filepath_str(self._filepath, self._protocol)
+        self._fs.invalidate_cache(path)

--- a/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
+++ b/kedro-datasets/kedro_datasets/huggingface/hugging_face_dataset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from copy import deepcopy
 from pathlib import PurePosixPath
-from typing import Any
+from typing import Any, TypeAlias
 
 import fsspec
 from datasets import (
@@ -24,7 +24,7 @@ from kedro.io.core import (
     get_protocol_and_path,
 )
 
-DatasetLike = Dataset | DatasetDict | IterableDataset | IterableDatasetDict
+DatasetLike: TypeAlias = Dataset | DatasetDict | IterableDataset | IterableDatasetDict
 
 
 class HFDataset(AbstractDataset[None, DatasetLike]):

--- a/kedro-datasets/mkdocs.yml
+++ b/kedro-datasets/mkdocs.yml
@@ -140,8 +140,9 @@ plugins:
 
         Machine Learning and AI:
           - api/kedro_datasets/tensorflow.TensorFlowModelDataset.md: TensorFlow model storage
-          - api/kedro_datasets/huggingface.HFDataset.md: HuggingFace datasets integration
-          - api/kedro_datasets/huggingface.HFTransformerPipelineDataset.md: HuggingFace transformer pipelines
+          - api/kedro_datasets/huggingface.HFDataset.md: Hugging Face remote datasets integration
+          - api/kedro_datasets/huggingface.HFTransformerPipelineDataset.md: Hugging Face transformer pipelines
+          - api/kedro_datasets/huggingface.LocalHFDataset.md: Hugging Face local datasets integration
 
         Visualization and Plotting:
           - api/kedro_datasets/matplotlib.MatplotlibDataset.md: Matplotlib figure storage
@@ -265,6 +266,7 @@ nav:
         - Huggingface:
           - huggingface.HFDataset: api/kedro_datasets/huggingface.HFDataset.md
           - huggingface.HFTransformerPipelineDataset: api/kedro_datasets/huggingface.HFTransformerPipelineDataset.md
+          - huggingface.LocalHFDataset: api/kedro_datasets/huggingface.LocalHFDataset.md
         - Ibis:
           - ibis.FileDataset: api/kedro_datasets/ibis.FileDataset.md
           - ibis.TableDataset: api/kedro_datasets/ibis.TableDataset.md

--- a/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
+++ b/kedro-datasets/static/jsonschema/kedro-catalog-1.0.0.json
@@ -19,6 +19,7 @@
               "holoviews.HoloviewsWriter",
               "huggingface.HFDataset",
               "huggingface.HFTransformerPipelineDataset",
+              "huggingface.LocalHFDataset",
               "ibis.FileDataset",
               "ibis.TableDataset",
               "json.JSONDataset",
@@ -447,6 +448,38 @@
                 "pipeline_kwargs": {
                   "type": "object",
                   "description": "Additional kwargs to be passed into the pipeline"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "huggingface.LocalHFDataset"
+                }
+              }
+            },
+            "then": {
+              "required": ["path"],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "description": "Path to a directory or file for persisting Hugging Face datasets. Supports local and remote filesystems (e.g. s3://)."
+                },
+                "file_format": {
+                  "type": "string",
+                  "enum": ["arrow", "parquet", "json", "csv", "lance", "hdf5"],
+                  "default": "arrow",
+                  "description": "The file format to use for saving and loading. Defaults to 'arrow'."
+                },
+                "load_args": {
+                  "type": "object",
+                  "description": "Additional arguments passed to the load method."
+                },
+                "save_args": {
+                  "type": "object",
+                  "description": "Additional arguments passed to the save method."
                 }
               }
             }

--- a/kedro-datasets/tests/huggingface/test_hugging_face_dataset.py
+++ b/kedro-datasets/tests/huggingface/test_hugging_face_dataset.py
@@ -1,7 +1,16 @@
+from pathlib import PurePosixPath
+
 import pytest
+from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict
+from fsspec.implementations.http import HTTPFileSystem
+from fsspec.implementations.local import LocalFileSystem
+from gcsfs import GCSFileSystem
 from huggingface_hub import HfApi
+from kedro.io.core import PROTOCOL_DELIMITER, DatasetError, Version
+from s3fs.core import S3FileSystem
 
 from kedro_datasets.huggingface import HFDataset
+from kedro_datasets.huggingface.hugging_face_dataset import LocalHFDataset
 
 
 @pytest.fixture
@@ -31,3 +40,332 @@ class TestHFDataset:
         datasets = HFDataset.list_datasets()
 
         assert datasets == expected_datasets
+
+
+@pytest.fixture
+def path_local_hf(tmp_path):
+    return (tmp_path / "test_hf_dataset").as_posix()
+
+
+@pytest.fixture
+def local_hf_dataset(path_local_hf, save_args, load_args, fs_args):
+    return LocalHFDataset(
+        path=path_local_hf,
+        save_args=save_args,
+        load_args=load_args,
+        fs_args=fs_args,
+    )
+
+
+@pytest.fixture
+def versioned_local_hf_dataset(path_local_hf, load_version, save_version):
+    return LocalHFDataset(
+        path=path_local_hf, version=Version(load_version, save_version)
+    )
+
+
+@pytest.fixture
+def dataset():
+    return Dataset.from_dict({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+
+
+@pytest.fixture
+def dataset_dict():
+    return DatasetDict(
+        {
+            "train": Dataset.from_dict({"col1": [1, 2], "col2": ["a", "b"]}),
+            "test": Dataset.from_dict({"col1": [3], "col2": ["c"]}),
+        }
+    )
+
+
+@pytest.fixture
+def iterable_dataset():
+    return Dataset.from_dict(
+        {"col1": [1, 2, 3], "col2": ["a", "b", "c"]}
+    ).to_iterable_dataset()
+
+
+@pytest.fixture
+def iterable_dataset_dict():
+    return IterableDatasetDict(
+        {
+            "train": Dataset.from_dict(
+                {"col1": [1, 2], "col2": ["a", "b"]}
+            ).to_iterable_dataset(),
+            "test": Dataset.from_dict(
+                {"col1": [3], "col2": ["c"]}
+            ).to_iterable_dataset(),
+        }
+    )
+
+
+@pytest.fixture
+def parquet_local_hf_dataset(path_local_hf):
+    return LocalHFDataset(path=path_local_hf, file_format="parquet")
+
+
+class TestLocalHFDataset:
+    def test_save_and_load_dataset(self, local_hf_dataset, dataset):
+        """Test saving and reloading a Dataset."""
+        local_hf_dataset.save(dataset)
+        reloaded = local_hf_dataset.load()
+        assert isinstance(reloaded, Dataset)
+        assert reloaded.to_dict() == dataset.to_dict()
+
+    def test_save_and_load_dataset_dict(self, local_hf_dataset, dataset_dict):
+        """Test saving and reloading a DatasetDict."""
+        local_hf_dataset.save(dataset_dict)
+        reloaded = local_hf_dataset.load()
+        assert isinstance(reloaded, DatasetDict)
+        assert set(reloaded.keys()) == {"train", "test"}
+        for split in dataset_dict:
+            assert reloaded[split].to_dict() == dataset_dict[split].to_dict()
+
+    def test_exists(self, local_hf_dataset, dataset):
+        """Test `exists` method for both existing and nonexistent dataset."""
+        assert not local_hf_dataset.exists()
+        local_hf_dataset.save(dataset)
+        assert local_hf_dataset.exists()
+
+    def test_exists_dataset_dict(self, local_hf_dataset, dataset_dict):
+        """Test `exists` method for DatasetDict (checks dataset_dict.json marker)."""
+        assert not local_hf_dataset.exists()
+        local_hf_dataset.save(dataset_dict)
+        assert local_hf_dataset.exists()
+
+    def test_save_and_load_iterable_dataset(self, local_hf_dataset, iterable_dataset):
+        """Test saving an IterableDataset materializes and round-trips."""
+        local_hf_dataset.save(iterable_dataset)
+        reloaded = local_hf_dataset.load()
+        assert isinstance(reloaded, Dataset)
+        assert reloaded.to_dict() == {
+            "col1": [1, 2, 3],
+            "col2": ["a", "b", "c"],
+        }
+
+    def test_save_and_load_iterable_dataset_dict(
+        self, local_hf_dataset, iterable_dataset_dict
+    ):
+        """Test saving an IterableDatasetDict materializes and round-trips."""
+        local_hf_dataset.save(iterable_dataset_dict)
+        reloaded = local_hf_dataset.load()
+        assert isinstance(reloaded, DatasetDict)
+        assert set(reloaded.keys()) == {"train", "test"}
+        assert reloaded["train"].to_dict() == {
+            "col1": [1, 2],
+            "col2": ["a", "b"],
+        }
+
+    def test_save_and_load_parquet(self, parquet_local_hf_dataset, dataset):
+        """Test saving and reloading a Dataset as parquet."""
+        parquet_local_hf_dataset.save(dataset)
+        reloaded = parquet_local_hf_dataset.load()
+        assert isinstance(reloaded, Dataset)
+        assert reloaded.to_dict() == dataset.to_dict()
+
+    def test_save_and_load_parquet_dataset_dict(
+        self, parquet_local_hf_dataset, dataset_dict
+    ):
+        """Test saving and reloading a DatasetDict as parquet."""
+        parquet_local_hf_dataset.save(dataset_dict)
+        reloaded = parquet_local_hf_dataset.load()
+        assert isinstance(reloaded, DatasetDict)
+        assert set(reloaded.keys()) == {"train", "test"}
+        for split in dataset_dict:
+            assert reloaded[split].to_dict() == dataset_dict[split].to_dict()
+
+    def test_exists_parquet(self, parquet_local_hf_dataset, dataset):
+        """Test `exists` for parquet format."""
+        assert not parquet_local_hf_dataset.exists()
+        parquet_local_hf_dataset.save(dataset)
+        assert parquet_local_hf_dataset.exists()
+
+    def test_save_and_load_json_dataset_dict(self, tmp_path, dataset_dict):
+        """Test saving and reloading a DatasetDict as JSON."""
+        path = (tmp_path / "test_json_dd").as_posix()
+        ds = LocalHFDataset(path=path, file_format="json")
+        ds.save(dataset_dict)
+        reloaded = ds.load()
+        assert isinstance(reloaded, DatasetDict)
+        assert set(reloaded.keys()) == {"train", "test"}
+        for split in dataset_dict:
+            assert reloaded[split].to_dict() == dataset_dict[split].to_dict()
+
+    def test_invalid_file_format(self):
+        """Test that an unsupported file_format raises DatasetError."""
+        pattern = r"Unsupported file_format"
+        with pytest.raises(DatasetError, match=pattern):
+            LocalHFDataset(path="test", file_format="xml")
+
+    @pytest.mark.parametrize("save_args", [{"num_shards": 2}], indirect=True)
+    def test_save_extra_params(self, local_hf_dataset, save_args):
+        """Test overriding the default save arguments."""
+        for key, value in save_args.items():
+            assert local_hf_dataset._save_args[key] == value
+
+    @pytest.mark.parametrize("load_args", [{"keep_in_memory": True}], indirect=True)
+    def test_load_extra_params(self, local_hf_dataset, load_args):
+        """Test overriding the default load arguments."""
+        for key, value in load_args.items():
+            assert local_hf_dataset._load_args[key] == value
+
+    def test_load_missing_dataset(self, local_hf_dataset):
+        """Check the error when trying to load missing dataset."""
+        pattern = r"Failed while loading data from dataset kedro_datasets.huggingface.hugging_face_dataset.LocalHFDataset\(.*\)"
+        with pytest.raises(DatasetError, match=pattern):
+            local_hf_dataset.load()
+
+    def test_save_invalid_type(self, local_hf_dataset):
+        """Check the error when saving an unsupported type."""
+        pattern = r"LocalHFDataset only supports .datasets.Dataset., .datasets.DatasetDict., .datasets.IterableDataset., and .datasets.IterableDatasetDict. instances."
+        with pytest.raises(DatasetError, match=pattern):
+            local_hf_dataset.save({"not": "a dataset"})
+
+    @pytest.mark.parametrize(
+        "path,instance_type",
+        [
+            ("s3://bucket/hf_data", S3FileSystem),
+            ("file:///tmp/hf_data", LocalFileSystem),
+            ("/tmp/hf_data", LocalFileSystem),
+            ("gcs://bucket/hf_data", GCSFileSystem),
+            ("https://example.com/hf_data", HTTPFileSystem),
+        ],
+    )
+    def test_protocol_usage(self, path, instance_type):
+        dataset = LocalHFDataset(path=path)
+        assert isinstance(dataset._fs, instance_type)
+
+        resolved = path.split(PROTOCOL_DELIMITER, 1)[-1]
+
+        assert str(dataset._filepath) == resolved
+        assert isinstance(dataset._filepath, PurePosixPath)
+
+    def test_pathlike_path(self, tmp_path, dataset):
+        """Test that os.PathLike paths are supported."""
+        path = tmp_path / "test_hf_pathlike"
+        ds = LocalHFDataset(path=path)
+        ds.save(dataset)
+        reloaded = ds.load()
+        assert reloaded.to_dict() == dataset.to_dict()
+
+    def test_catalog_release(self, mocker):
+        fs_mock = mocker.patch("fsspec.filesystem").return_value
+        path = "test_hf"
+        dataset = LocalHFDataset(path=path)
+        dataset.release()
+        fs_mock.invalidate_cache.assert_called_once_with(path)
+
+
+class TestLocalHFDatasetVersioned:
+    def test_version_str_repr(self, load_version, save_version):
+        """Test that version is in string representation of the class instance
+        when applicable."""
+        path = "test_hf_dataset"
+        ds = LocalHFDataset(path=path)
+        ds_versioned = LocalHFDataset(
+            path=path, version=Version(load_version, save_version)
+        )
+        assert path in str(ds)
+        assert "version" not in str(ds)
+
+        assert path in str(ds_versioned)
+        ver_str = f"version=Version(load={load_version}, save='{save_version}')"
+        assert ver_str in str(ds_versioned)
+        assert "LocalHFDataset" in str(ds_versioned)
+        assert "LocalHFDataset" in str(ds)
+        assert "protocol" in str(ds_versioned)
+        assert "protocol" in str(ds)
+
+    def test_save_and_load(self, versioned_local_hf_dataset, dataset):
+        """Test that saved and reloaded data matches the original one for
+        the versioned dataset."""
+        versioned_local_hf_dataset.save(dataset)
+        reloaded = versioned_local_hf_dataset.load()
+        assert reloaded.to_dict() == dataset.to_dict()
+
+    def test_save_and_load_dataset_dict(self, versioned_local_hf_dataset, dataset_dict):
+        """Test versioned save and reload with DatasetDict."""
+        versioned_local_hf_dataset.save(dataset_dict)
+        reloaded = versioned_local_hf_dataset.load()
+        assert isinstance(reloaded, DatasetDict)
+        for split in dataset_dict:
+            assert reloaded[split].to_dict() == dataset_dict[split].to_dict()
+
+    def test_save_and_load_iterable_dataset(
+        self, versioned_local_hf_dataset, iterable_dataset
+    ):
+        """Test versioned save with IterableDataset."""
+        versioned_local_hf_dataset.save(iterable_dataset)
+        reloaded = versioned_local_hf_dataset.load()
+        assert isinstance(reloaded, Dataset)
+        assert reloaded.to_dict() == {
+            "col1": [1, 2, 3],
+            "col2": ["a", "b", "c"],
+        }
+
+    def test_save_and_load_iterable_dataset_dict(
+        self, versioned_local_hf_dataset, iterable_dataset_dict
+    ):
+        """Test versioned save with IterableDatasetDict."""
+        versioned_local_hf_dataset.save(iterable_dataset_dict)
+        reloaded = versioned_local_hf_dataset.load()
+        assert isinstance(reloaded, DatasetDict)
+        assert set(reloaded.keys()) == {"train", "test"}
+
+    def test_no_versions(self, versioned_local_hf_dataset):
+        """Check the error if no versions are available for load."""
+        pattern = r"Did not find any versions for kedro_datasets.huggingface.hugging_face_dataset.LocalHFDataset\(.+\)"
+        with pytest.raises(DatasetError, match=pattern):
+            versioned_local_hf_dataset.load()
+
+    def test_exists(self, versioned_local_hf_dataset, dataset):
+        """Test `exists` method invocation for versioned dataset."""
+        assert not versioned_local_hf_dataset.exists()
+        versioned_local_hf_dataset.save(dataset)
+        assert versioned_local_hf_dataset.exists()
+
+    def test_prevent_overwrite(self, versioned_local_hf_dataset, dataset):
+        """Check the error when attempting to override the dataset if the
+        corresponding version already exists."""
+        versioned_local_hf_dataset.save(dataset)
+        pattern = (
+            r"Save path \'.+\' for kedro_datasets.huggingface.hugging_face_dataset.LocalHFDataset\(.+\) must "
+            r"not exist if versioning is enabled\."
+        )
+        with pytest.raises(DatasetError, match=pattern):
+            versioned_local_hf_dataset.save(dataset)
+
+    @pytest.mark.parametrize(
+        "load_version", ["2019-01-01T23.59.59.999Z"], indirect=True
+    )
+    @pytest.mark.parametrize(
+        "save_version", ["2019-01-02T00.00.00.000Z"], indirect=True
+    )
+    def test_save_version_warning(
+        self, versioned_local_hf_dataset, load_version, save_version, dataset
+    ):
+        """Check the warning when saving to the path that differs from
+        the subsequent load path."""
+        pattern = (
+            f"Save version '{save_version}' did not match "
+            f"load version '{load_version}' for "
+            r"kedro_datasets.huggingface.hugging_face_dataset.LocalHFDataset\(.+\)"
+        )
+        with pytest.warns(UserWarning, match=pattern):
+            versioned_local_hf_dataset.save(dataset)
+
+    def test_http_filesystem_no_versioning(self):
+        pattern = "Versioning is not supported for HTTP protocols."
+
+        with pytest.raises(DatasetError, match=pattern):
+            LocalHFDataset(
+                path="https://example.com/hf_data",
+                version=Version(None, None),
+            )
+
+    def test_save_invalid_type_versioned(self, versioned_local_hf_dataset):
+        """Check the error when saving an unsupported type through versioned dataset."""
+        pattern = r"LocalHFDataset only supports .datasets.Dataset., .datasets.DatasetDict., .datasets.IterableDataset., and .datasets.IterableDatasetDict. instances."
+        with pytest.raises(DatasetError, match=pattern):
+            versioned_local_hf_dataset.save("not a dataset")


### PR DESCRIPTION
## Description

Adds `LocalHFDataset` for interacting with `datasets.Dataset` on a filesystem instead of the remote Hugging Face hub.

This has been a big missing feature for me when using `huggingface.HFDataset`. We can pull things from the hub, but not save them off to a local file / directory.

## Development notes

Added docs, tests, ran in a fresh pipeline.

Iterable and in-memory versions have both been tested as well. 

> [!Note]
> I couldn't figure out a good way to save an `IterableDataset` without looping through it entirely first.
> 
> Maybe there's a better way someone knows about.

Updated `jsonschema/kedro-catalog.1.00.json`.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Updated `jsonschema/kedro-catalog-X.XX.json` if necessary
- [x] Added a description of this change in the relevant `RELEASE.md` file
- [x] Added tests to cover my changes
- [ ] Received approvals from at least half of the TSC (required for adding a new, non-experimental dataset)
